### PR TITLE
TNT-39272 - allocation provider and hash_unencoded_chars impl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ tzlocal==2.1
 python-dateutil==2.8.1
 ua-parser==0.10.0
 user-agents==2.2.0
+enum34==1.1.10

--- a/target_decisioning_engine/allocation_provider.py
+++ b/target_decisioning_engine/allocation_provider.py
@@ -1,0 +1,75 @@
+# Copyright 2021 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+"""Allocation provider"""
+from target_decisioning_engine.constants import CAMPAIGN_BUCKET_SALT
+from target_python_sdk.utils import is_string
+from target_python_sdk.utils import create_uuid
+from target_tools.hashing import hash_unencoded_chars
+from target_tools.utils import memoize
+
+TOTAL_BUCKETS = 10000
+MAX_PERCENTAGE = 100
+
+
+def valid_tnt_id(tnt_id=None):
+    """
+    :param tnt_id: (str) tntId
+    :return: (str) tntId without the location hint
+    """
+    if tnt_id and is_string(tnt_id):
+        return tnt_id.split(".")[0]
+    return None
+
+
+def get_or_create_visitor_id(visitor_id):
+    """
+    :param visitor_id: (delivery_api_client.Model.visitor_id.VisitorId) visitor ID object
+    :return: (str) Returns visitor ID that will be used to compute the allocation
+    """
+    if not visitor_id:
+        return create_uuid()
+
+    return (
+        visitor_id.marketing_cloud_visitor_id or
+        valid_tnt_id(visitor_id.tnt_id) or
+        visitor_id.third_party_id or
+        create_uuid()
+    )
+
+
+def _calculate_allocation(device_id):
+    """
+    :param device_id: (str) device id based on visitorId, clientCode, campaignId and a salt value
+    :return: (float) allocation value
+    """
+    signed_numeric_hash_value = hash_unencoded_chars(device_id)
+    hash_fixed_bucket = abs(signed_numeric_hash_value) % TOTAL_BUCKETS
+    allocation_value = (hash_fixed_bucket / TOTAL_BUCKETS) * MAX_PERCENTAGE
+    return round(allocation_value, 2)
+
+
+calculate_allocation_memoized = memoize(_calculate_allocation)
+
+
+def compute_allocation(client_id, activity_id, visitor_id, salt=CAMPAIGN_BUCKET_SALT):
+    """
+    :param client_id: (str) client ID
+    :param activity_id: (str) activity ID
+    :param visitor_id: (str | delivery_api_client.Model.visitor_id.VisitorId) visitor ID
+    :param salt: (str) hashing salt
+    :return: (float) allocation value
+    """
+    device_id = ".".join([
+        client_id,
+        activity_id,
+        visitor_id if visitor_id and is_string(visitor_id) else get_or_create_visitor_id(visitor_id),
+        salt
+    ])
+    return calculate_allocation_memoized(device_id)

--- a/target_decisioning_engine/allocation_provider.py
+++ b/target_decisioning_engine/allocation_provider.py
@@ -51,7 +51,7 @@ def _calculate_allocation(device_id):
     """
     signed_numeric_hash_value = hash_unencoded_chars(device_id)
     hash_fixed_bucket = abs(signed_numeric_hash_value) % TOTAL_BUCKETS
-    allocation_value = (hash_fixed_bucket / TOTAL_BUCKETS) * MAX_PERCENTAGE
+    allocation_value = (hash_fixed_bucket / float(TOTAL_BUCKETS)) * MAX_PERCENTAGE
     return round(allocation_value, 2)
 
 

--- a/target_decisioning_engine/constants.py
+++ b/target_decisioning_engine/constants.py
@@ -39,7 +39,7 @@ CDN_BASE = {
     ENVIRONMENT_DEV: CDN_BASE_DEV
 }
 
-CAMPAIGN_BUCKET_SALT = "campaign"
+CAMPAIGN_BUCKET_SALT = "0"
 
 # Response token keys
 AUDIENCE_IDS = "audience.ids"

--- a/target_decisioning_engine/tests/test_allocation_provider.py
+++ b/target_decisioning_engine/tests/test_allocation_provider.py
@@ -1,0 +1,129 @@
+# Copyright 2021 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+"""Test cases for target_decisioning_enging.allocation_provider module"""
+import unittest
+
+from delivery_api_client import VisitorId
+from delivery_api_client import CustomerId
+from delivery_api_client import AuthenticatedState
+from target_decisioning_engine.allocation_provider import compute_allocation
+from target_decisioning_engine.allocation_provider import get_or_create_visitor_id
+from target_decisioning_engine.allocation_provider import valid_tnt_id
+
+CLIENT_ID = "someClientId"
+ACTIVITY_ID = "123456"
+SALT = "salty"
+
+
+class TestAllocationProvider(unittest.TestCase):
+
+    def test_compute_allocation_visitor_id_str(self):
+        visitor_id = "ecid123"
+        allocation = compute_allocation(CLIENT_ID, ACTIVITY_ID, visitor_id, SALT)
+        self.assertEqual(allocation, 29.06)
+
+    def test_compute_allocation_ecid(self):
+        visitor_id = VisitorId(marketing_cloud_visitor_id="ecid123")
+        allocation = compute_allocation(CLIENT_ID, ACTIVITY_ID, visitor_id, SALT)
+        self.assertEqual(allocation, 29.06)
+
+    def test_compute_allocation_tnt_id(self):
+        visitor_id = VisitorId(tnt_id="tntId123")
+        allocation = compute_allocation(CLIENT_ID, ACTIVITY_ID, visitor_id, SALT)
+        self.assertEqual(allocation, 21.94)
+
+    def test_compute_allocation_tnt_id_with_location_hint(self):
+        visitor_id = VisitorId(tnt_id="tntId123.28_0")
+        allocation = compute_allocation(CLIENT_ID, ACTIVITY_ID, visitor_id, SALT)
+        self.assertEqual(allocation, 21.94)
+
+    def test_compute_allocation_third_party_id(self):
+        visitor_id = VisitorId(third_party_id="thirtPartyId123")
+        allocation = compute_allocation(CLIENT_ID, ACTIVITY_ID, visitor_id, SALT)
+        self.assertEqual(allocation, 73.15)
+
+    def test_compute_allocation_generate_visitor_id(self):
+        visitor_id = None
+        allocation = compute_allocation(CLIENT_ID, ACTIVITY_ID, visitor_id, SALT)
+        self.assertTrue(isinstance(allocation, float))
+        self.assertTrue(allocation >= 0)
+        self.assertTrue(allocation < 100)
+
+        visitor_id = VisitorId()
+        allocation = compute_allocation(CLIENT_ID, ACTIVITY_ID, visitor_id, SALT)
+        self.assertTrue(isinstance(allocation, float))
+        self.assertTrue(allocation >= 0)
+        self.assertTrue(allocation < 100)
+
+    def test_get_or_create_visitor_id_uses_ecid(self):
+        customer_id = CustomerId(id="custId123", integration_code="A", authenticated_state=AuthenticatedState.UNKNOWN)
+        visitor_id = VisitorId(tnt_id="tnt123",
+                               marketing_cloud_visitor_id="mcid123",
+                               customer_ids=[customer_id],
+                               third_party_id="thirtPartyId123")
+        result = get_or_create_visitor_id(visitor_id)
+        self.assertEqual(result, "mcid123")
+
+    def test_get_or_create_visitor_id_uses_tnt_id(self):
+        customer_id = CustomerId(id="custId123", integration_code="A", authenticated_state=AuthenticatedState.UNKNOWN)
+        visitor_id = VisitorId(tnt_id="tnt123",
+                               customer_ids=[customer_id],
+                               third_party_id="thirtPartyId123")
+        result = get_or_create_visitor_id(visitor_id)
+        self.assertEqual(result, "tnt123")
+
+    def test_get_or_create_visitor_id_uses_third_party_id(self):
+        customer_id = CustomerId(id="custId123", integration_code="A", authenticated_state=AuthenticatedState.UNKNOWN)
+        visitor_id = VisitorId(customer_ids=[customer_id],
+                               third_party_id="thirtPartyId123")
+        result = get_or_create_visitor_id(visitor_id)
+        self.assertEqual(result, "thirtPartyId123")
+
+    def test_get_or_create_visitor_id_never_uses_customer_id(self):
+        customer_ids = [
+            CustomerId(id="custId123unknown", integration_code="A", authenticated_state=AuthenticatedState.UNKNOWN),
+            CustomerId(id="custId123loggedout", integration_code="A",
+                       authenticated_state=AuthenticatedState.LOGGED_OUT),
+            CustomerId(id="custId123authenticated", integration_code="A",
+                       authenticated_state=AuthenticatedState.AUTHENTICATED)
+        ]
+        visitor_id = VisitorId(customer_ids=customer_ids)
+        result = get_or_create_visitor_id(visitor_id)
+        self.assertTrue(isinstance(result, str))
+        self.assertGreater(len(result), 0)
+        self.assertIsNot(result, "custId123unknown")
+        self.assertIsNot(result, "custId123loggedout")
+        self.assertIsNot(result, "custId123authenticated")
+
+    def test_get_or_create_visitor_id_generate_id(self):
+        result = get_or_create_visitor_id("")
+        self.assertTrue(isinstance(result, str))
+        self.assertGreater(len(result), 0)
+
+    def test_valid_tnt_id_strips_off_cluster(self):
+        result = valid_tnt_id("338e3c1e51f7416a8e1ccba4f81acea0.28_0")
+        self.assertEqual(result, "338e3c1e51f7416a8e1ccba4f81acea0")
+
+    def test_valid_tnt_id_no_cluster(self):
+        result = valid_tnt_id("338e3c1e51f7416a8e1ccba4f81acea0")
+        self.assertEqual(result, "338e3c1e51f7416a8e1ccba4f81acea0")
+
+    def test_valid_tnt_id_invalid(self):
+        result = valid_tnt_id("")
+        self.assertIsNone(result)
+
+        result = valid_tnt_id(None)
+        self.assertIsNone(result)
+
+        result = valid_tnt_id()
+        self.assertIsNone(result)
+
+        result = valid_tnt_id(100)
+        self.assertIsNone(result)

--- a/target_python_sdk/cookies.py
+++ b/target_python_sdk/cookies.py
@@ -99,5 +99,5 @@ def create_target_cookie(cookies):
     return {
         'name': TARGET_COOKIE,
         'value': "|".join(serialized_cookies),
-        'maxAge': math.ceil(max_age // MILLISECONDS_IN_SECOND)
+        'maxAge': math.ceil(float(max_age) / MILLISECONDS_IN_SECOND)
     }

--- a/target_python_sdk/cookies.py
+++ b/target_python_sdk/cookies.py
@@ -99,5 +99,5 @@ def create_target_cookie(cookies):
     return {
         'name': TARGET_COOKIE,
         'value': "|".join(serialized_cookies),
-        'maxAge': math.ceil(max_age / MILLISECONDS_IN_SECOND)
+        'maxAge': math.ceil(max_age // MILLISECONDS_IN_SECOND)
     }

--- a/target_tools/hashing.py
+++ b/target_tools/hashing.py
@@ -9,6 +9,7 @@
 # governing permissions and limitations under the License.
 """Hashing functions"""
 # pylint: disable=invalid-name
+# pylint: disable=unused-argument
 
 import ctypes
 from target_tools.utils import memoize
@@ -81,9 +82,9 @@ def hash_unencoded_chars_raw(string_value, seed=0):
     return h1
 
 
-def _create_memoization_key(_list):
+def _create_memoization_key(args, kwargs):
     """Joins list of values to create memo cache key"""
-    return "-".join(_list)
+    return "-".join(args)
 
 
 hash_unencoded_chars = memoize(hash_unencoded_chars_raw, _create_memoization_key)

--- a/target_tools/hashing.py
+++ b/target_tools/hashing.py
@@ -1,0 +1,89 @@
+# Copyright 2021 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+"""Hashing functions"""
+# pylint: disable=invalid-name
+
+import ctypes
+from target_tools.utils import memoize
+
+
+def zero_fill_right_shift(val, n):
+    """bitwise >>>"""
+    return (val >> n) if val >= 0 else ((val + 0x100000000) >> n)
+
+
+def char_code_at(string_value, index):
+    """Gets unicode value of character at given index of string_value"""
+    return ord(string_value[index])
+
+
+def int32(val):
+    """Convert standard python int value into a 32-bit signed int"""
+    return ctypes.c_int(val).value
+
+
+def mul32(m, n):
+    """mul32"""
+    nlo = n & 0xffff
+    nhi = n - nlo
+    return int32(int32(int32(nhi * m ^ 0) | 0) + int32(int32(nlo * m) | 0)) | 0
+
+
+def hash_unencoded_chars_raw(string_value, seed=0):
+    """Optimized MurmurHash3 (32-bit) hashing algorithm to generate a signed numeric 10-digit hash
+    This method matches the java method used on Target Edge
+    :param string_value: (str) string to hash
+    :param seed: (int) seed value
+    :return: (int) Returns 10-digit signed int hash value
+    """
+    length = len(string_value)
+    c1 = 0xcc9e2d51
+    c2 = 0x1b873593
+
+    h1 = seed
+    rounded_end = length & ~0x1
+
+    for i in range(0, rounded_end, 2):
+        k1 = char_code_at(string_value, i) | (char_code_at(string_value, i + 1) << 16)
+
+        k1 = mul32(k1, c1)
+        k1 = (int32((k1 & 0x1ffff) << 15)) | int32(zero_fill_right_shift(k1, 17))  # ROTL32(k1,15)
+        k1 = mul32(k1, c2)
+
+        h1 ^= k1
+        h1 = int32(int32(h1 & 0x7ffff) << 13) | int32(zero_fill_right_shift(h1, 19))  # ROTL32(h1,13)
+        h1 = int32(h1 * 5 + 0xe6546b64) | 0
+
+    if length % 2 == 1:
+        k1 = char_code_at(string_value, rounded_end)
+        k1 = mul32(k1, c1)
+        k1 = int32(int32(k1 & 0x1ffff) << 15) | int32(zero_fill_right_shift(k1, 17))  # ROTL32(k1,15)
+        k1 = mul32(k1, c2)
+        h1 ^= k1
+
+    # finalization
+    h1 ^= length << 1
+
+    # fmix(h1)
+    h1 ^= int32(zero_fill_right_shift(h1, 16))
+    h1 = mul32(h1, 0x85ebca6b)
+    h1 ^= int32(zero_fill_right_shift(h1, 13))
+    h1 = mul32(h1, 0xc2b2ae35)
+    h1 ^= int32(zero_fill_right_shift(h1, 16))
+
+    return h1
+
+
+def _create_memoization_key(_list):
+    """Joins list of values to create memo cache key"""
+    return "-".join(_list)
+
+
+hash_unencoded_chars = memoize(hash_unencoded_chars_raw, _create_memoization_key)

--- a/target_tools/utils.py
+++ b/target_tools/utils.py
@@ -158,3 +158,18 @@ def get_view_names(delivery_request):
 def noop():
     """No-Op function for when callable is required"""
     return None
+
+
+def memoize(func, args_resolver=None):
+    """Function memoization for better performance"""
+    cache = dict()
+
+    def memoized_func(*args):
+        key = args_resolver(args) if args_resolver else args
+        if key in cache:
+            return cache[key]
+        result = func(*args)
+        cache[key] = result
+        return result
+
+    return memoized_func

--- a/target_tools/utils.py
+++ b/target_tools/utils.py
@@ -164,11 +164,11 @@ def memoize(func, args_resolver=None):
     """Function memoization for better performance"""
     cache = dict()
 
-    def memoized_func(*args):
-        key = args_resolver(args) if args_resolver else args
+    def memoized_func(*args, **kwargs):
+        key = args_resolver(args, kwargs) if args_resolver else (args, frozenset(kwargs.items()))
         if key in cache:
             return cache[key]
-        result = func(*args)
+        result = func(*args, **kwargs)
         cache[key] = result
         return result
 


### PR DESCRIPTION
- Allocation Provider
- Salt value set to 0
- hash_unencoded_chars implementation that matches Edge functionality.  I was unable to find a Python version of the Guava impl, so I ported the nodejs sdk's hashUnencodedChars.
