### PR TITLE
TNT-42098 - ODD artifact should be limited to property-specific activities if property_token included

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,4 +7,4 @@ no-docstring-rgx=^[tT]est*
 # Minimum lines number of a similarity.
 min-similarity-lines=30
 
-disable=W0212,R0205,R0904,R0201,R0401,W0231,R0902,W0703,W0613,R0903,R0913,W0231
+disable=W0212,R0205,R0904,R0201,R0401,W0231,R0902,W0703,W0613,R0903,R0913,W0231,W1514

--- a/target_decisioning_engine/tests/test_utils.py
+++ b/target_decisioning_engine/tests/test_utils.py
@@ -132,8 +132,8 @@ class TestUtils(unittest.TestCase):
                                    property_token="693de2cd-ac92-d2c7-59fc-a3c0f2bce646")
         artifact_location = determine_artifact_location(config)
         self.assertEqual(artifact_location,
-                         "https://assets.staging.adobetarget.com/MyClient/development/v1/ \
-                         693de2cd-ac92-d2c7-59fc-a3c0f2bce646/rules.json")
+                         """https://assets.staging.adobetarget.com/MyClient/development/v1/
+                         693de2cd-ac92-d2c7-59fc-a3c0f2bce646/rules.json""")
 
     def test_determine_artifact_location_invalid_env(self):
         config = DecisioningConfig("MyClient", "12345@AdobeOrg", environment="bad")

--- a/target_decisioning_engine/tests/test_utils.py
+++ b/target_decisioning_engine/tests/test_utils.py
@@ -119,12 +119,21 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(set(result.get("remote_mboxes")), set(["mbox1", "mbox3"]))
         self.assertEqual(set(result.get("remote_views")), set(["view1", "view3"]))
 
-    def test_determine_artifact_location(self):
+    def test_determine_artifact_location_without_property(self):
         config = DecisioningConfig("MyClient", "12345@AdobeOrg", environment=ENVIRONMENT_DEV,
                                    cdn_environment=ENVIRONMENT_STAGE)
         artifact_location = determine_artifact_location(config)
         self.assertEqual(artifact_location,
                          "https://assets.staging.adobetarget.com/MyClient/development/v1/rules.json")
+
+    def test_determine_artifact_location_with_property(self):
+        config = DecisioningConfig("MyClient", "12345@AdobeOrg", environment=ENVIRONMENT_DEV,
+                                   cdn_environment=ENVIRONMENT_STAGE,
+                                   property_token="693de2cd-ac92-d2c7-59fc-a3c0f2bce646")
+        artifact_location = determine_artifact_location(config)
+        self.assertEqual(artifact_location,
+                         "https://assets.staging.adobetarget.com/MyClient/development/v1/ \
+                         693de2cd-ac92-d2c7-59fc-a3c0f2bce646/rules.json")
 
     def test_determine_artifact_location_invalid_env(self):
         config = DecisioningConfig("MyClient", "12345@AdobeOrg", environment="bad")

--- a/target_decisioning_engine/tests/test_utils.py
+++ b/target_decisioning_engine/tests/test_utils.py
@@ -132,8 +132,8 @@ class TestUtils(unittest.TestCase):
                                    property_token="693de2cd-ac92-d2c7-59fc-a3c0f2bce646")
         artifact_location = determine_artifact_location(config)
         self.assertEqual(artifact_location,
-                         """https://assets.staging.adobetarget.com/MyClient/development/v1/
-                         693de2cd-ac92-d2c7-59fc-a3c0f2bce646/rules.json""")
+                         "https://assets.staging.adobetarget.com/MyClient/development/v1/" +
+                         "693de2cd-ac92-d2c7-59fc-a3c0f2bce646/rules.json")
 
     def test_determine_artifact_location_invalid_env(self):
         config = DecisioningConfig("MyClient", "12345@AdobeOrg", environment="bad")

--- a/target_decisioning_engine/types/decisioning_config.py
+++ b/target_decisioning_engine/types/decisioning_config.py
@@ -16,7 +16,7 @@ class DecisioningConfig:
     def __init__(self, client, organization_id, polling_interval=None,
                  artifact_location=None, artifact_payload=None, environment=None,
                  cdn_environment=None, cdn_base_path=None, send_notification_func=None,
-                 telemetry_enabled=True, event_emitter=None, maximum_wait_ready=None):
+                 telemetry_enabled=True, event_emitter=None, maximum_wait_ready=None, property_token=None):
         """
         :param client: (str) Target Client Id
         :param organization_id: (str) Target Organization Id
@@ -31,6 +31,7 @@ class DecisioningConfig:
         :param event_emitter: (callable) Function used to emit events
         :param maximum_wait_ready: (int) The maximum amount of time (in seconds) to wait for decisioning engine to
             become ready.  Default is to wait indefinitely.
+        :param property_token: (str) A property token used to limit the scope of evaluated target activities
         """
         self.client = client
         self.organization_id = organization_id
@@ -45,3 +46,4 @@ class DecisioningConfig:
         self.event_emitter = event_emitter if event_emitter and callable(event_emitter) else \
             lambda event_name, payload: None
         self.maximum_wait_ready = maximum_wait_ready
+        self.property_token = property_token

--- a/target_decisioning_engine/utils.py
+++ b/target_decisioning_engine/utils.py
@@ -188,6 +188,7 @@ def determine_artifact_location(config):
         config.client,
         target_environment,
         "v{}".format(SUPPORTED_ARTIFACT_MAJOR_VERSION),
+        config.property_token,
         ARTIFACT_FILENAME
     ]
     filtered = filter(None, location_parts)

--- a/target_python_sdk/__init__.py
+++ b/target_python_sdk/__init__.py
@@ -74,7 +74,8 @@ class TargetClient:
                                                        send_notification_func=self.send_notifications,
                                                        telemetry_enabled=self.config.get("telemetry_enabled"),
                                                        event_emitter=self.event_emitter,
-                                                       maximum_wait_ready=self.config.get("maximum_wait_ready"))
+                                                       maximum_wait_ready=self.config.get("maximum_wait_ready"),
+                                                       property_token=self.config.get("property_token"))
                 self.decisioning_engine = TargetDecisioningEngine(decisioning_config)
                 self.decisioning_engine.initialize()
                 self.event_emitter(CLIENT_READY)

--- a/target_tools/tests/test_logger.py
+++ b/target_tools/tests/test_logger.py
@@ -15,15 +15,14 @@ import target_tools
 from target_tools.logger import get_logger
 from target_tools.logger import LOGGER_NAME
 
-try:
-    import imp
-    reload = imp.reload
-except ImportError:
+if six.PY3:
     try:
         import importlib
         reload = importlib.reload
     except ImportError:
-        pass  # use builtin reload()
+        import imp
+        reload = imp.reload
+# else use builtin reload() for Python 2.7
 
 
 def clear_logger_import_cache():

--- a/target_tools/tests/test_logger.py
+++ b/target_tools/tests/test_logger.py
@@ -9,9 +9,8 @@
 # governing permissions and limitations under the License.
 """Test cases for logger"""
 import logging
-import six
 import unittest
-
+import six
 import target_tools
 from target_tools.logger import get_logger
 from target_tools.logger import LOGGER_NAME

--- a/target_tools/tests/test_logger.py
+++ b/target_tools/tests/test_logger.py
@@ -9,6 +9,7 @@
 # governing permissions and limitations under the License.
 """Test cases for logger"""
 import logging
+import six
 import unittest
 
 import target_tools

--- a/target_tools/tests/test_logger.py
+++ b/target_tools/tests/test_logger.py
@@ -20,7 +20,7 @@ if six.PY3:
         import importlib
         reload = importlib.reload
     except ImportError:
-        import imp
+        import imp # pylint: disable=deprecated-module
         reload = imp.reload
 # else use builtin reload() for Python 2.7
 

--- a/target_tools/utils.py
+++ b/target_tools/utils.py
@@ -174,7 +174,7 @@ def noop(*args, **kwargs):
 
 def memoize(func, args_resolver=None):
     """Function memoization for better performance"""
-    cache = dict()
+    cache = {}
 
     def memoized_func(*args, **kwargs):
         key = args_resolver(args, kwargs) if args_resolver else (args, frozenset(kwargs.items()))


### PR DESCRIPTION
1. Prior to this change, the java SDK always downloaded the "global" rules.json file, so that it could answer calls for any property -- even if the SDK had been configured with a property token on init. But this change makes it so the SDK downloads the property-specific artifact only if one is specified on init. This helps for those with server-side constraints where large artifact sizes are not ideal.
2. Fixed a few lint errors

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
